### PR TITLE
Ensure initializeFromUrl runs once

### DIFF
--- a/src/components/TestHarness.tsx
+++ b/src/components/TestHarness.tsx
@@ -37,7 +37,7 @@ const TestHarness: React.FC = () => {
 
   useEffect(() => {
     initializeFromUrl()
-  }, [initializeFromUrl])
+  }, [])
 
   // Redirect to login if not authenticated
   if (!isAuthenticated) {


### PR DESCRIPTION
## Summary
- run `initializeFromUrl` only on mount in `TestHarness`

## Testing
- `npm run format:check`
- `npm run type-check`
- `npm run lint` (shows a warning about missing dependency)