### PR TITLE
Integrate ArtifactFrameHolder

### DIFF
--- a/frame.html
+++ b/frame.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Artifact Frame</title>
+  </head>
+  <body>
+    <div id="frame-root"></div>
+    <script type="module" src="/src/frame.tsx"></script>
+  </body>
+</html>

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,3 @@
 export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {}
-  }
+  plugins: {},
 }

--- a/src/components/TestHarness.tsx
+++ b/src/components/TestHarness.tsx
@@ -1,6 +1,8 @@
-import { useEffect } from 'react'
+import React, { useEffect } from 'react'
 import Dashboard from './Dashboard'
-import ComponentUnderTest from './ComponentUnderTest'
+import { ArtifactFrameHolder } from '@artifact/client'
+import { HOST_SCOPE } from '@artifact/client/api'
+import { usePrivy } from '@privy-io/react-auth'
 import { ScreenSize, BackgroundType } from '../types'
 import { useHarnessStore } from '../store/useHarnessStore'
 
@@ -34,6 +36,20 @@ const TestHarness: React.FC = () => {
     scope,
     initializeFromUrl
   } = useHarnessStore()
+  const { user } = usePrivy()
+  const did = user?.id
+  const frameUrl = React.useMemo(() => {
+    const base = frameSource || '/frame.html'
+    const url = new URL(base, window.location.origin)
+    url.searchParams.set('apiUrl', apiUrl)
+    url.searchParams.set('frameSource', base)
+    url.searchParams.set('privyAppId', privyAppId)
+    if (scope.repo) url.searchParams.set('repo', scope.repo)
+    if (scope.branch) url.searchParams.set('branch', scope.branch)
+    if (scope.commit) url.searchParams.set('commit', scope.commit)
+    if (scope.path) url.searchParams.set('path', scope.path)
+    return url.toString()
+  }, [apiUrl, frameSource, privyAppId, scope])
 
   useEffect(() => {
     initializeFromUrl()
@@ -92,12 +108,23 @@ const TestHarness: React.FC = () => {
                 ${showBorder ? 'bg-white p-4' : ''}
               `}
               >
-                <ComponentUnderTest
-                  apiUrl={apiUrl}
-                  frameSource={frameSource}
-                  privyAppId={privyAppId}
-                  scope={scope}
-                />
+                <ArtifactFrameHolder
+                  src={frameUrl}
+                  target={{
+                    ...HOST_SCOPE,
+                    ...scope,
+                    did: did || HOST_SCOPE.did
+                  }}
+                  diffs={[]}
+                  access={[]}
+                  selection={undefined}
+                  onSelection={() => {}}
+                  onMessage={() => {}}
+                  onAccessRequest={() => {}}
+                  onNavigateTo={() => {}}
+                >
+                  {null}
+                </ArtifactFrameHolder>
               </div>
             </div>
           </div>

--- a/src/frame.tsx
+++ b/src/frame.tsx
@@ -1,0 +1,39 @@
+import { createRoot } from 'react-dom/client'
+import { ArtifactFrame } from '@artifact/client'
+import { HOST_SCOPE } from '@artifact/client/api'
+import ComponentUnderTest from './components/ComponentUnderTest'
+
+function FrameApp() {
+  const params = new URLSearchParams(window.location.search)
+  const apiUrl = params.get('apiUrl') || 'https://api.example.com'
+  const frameSource = params.get('frameSource') || ''
+  const privyAppId = params.get('privyAppId') || ''
+  const scope = {
+    repo: params.get('repo') || '',
+    branch: params.get('branch') || '',
+    commit: params.get('commit') || '',
+    path: params.get('path') || ''
+  }
+
+  return (
+    <ArtifactFrame
+      target={{ ...HOST_SCOPE, ...scope }}
+      access={[]}
+      selection={undefined}
+      diffs={[]}
+      onSelection={() => {}}
+      onMessage={() => {}}
+      onAccessRequest={() => {}}
+      onNavigateTo={() => {}}
+    >
+      <ComponentUnderTest
+        apiUrl={apiUrl}
+        frameSource={frameSource}
+        privyAppId={privyAppId}
+        scope={scope}
+      />
+    </ArtifactFrame>
+  )
+}
+
+createRoot(document.getElementById('frame-root')!).render(<FrameApp />)

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,5 +16,13 @@ export default defineConfig({
       'Cross-Origin-Opener-Policy': 'unsafe-none'
     }
   },
-  base: './'
+  base: './',
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        frame: path.resolve(__dirname, 'frame.html')
+      }
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- integrate `ArtifactFrameHolder` from `@artifact/client`
- add a separate `frame.html` document served by Vite
- implement new `FrameApp` entry to mount `ArtifactFrame`
- generate URL parameters for the frame holder
- allow Vite to build multiple HTML entry points
- stub PostCSS config for the build

## Testing
- `npm run format`
- `npm run type-check`
- `npm run lint`
- `npm run build`
- `npm test --if-present`