### PR TITLE
Fix lint warnings and update Tailwind config

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,6 @@
 export default {
-  plugins: {},
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
 }

--- a/src/components/TestHarness.tsx
+++ b/src/components/TestHarness.tsx
@@ -53,7 +53,7 @@ const TestHarness: React.FC = () => {
 
   useEffect(() => {
     initializeFromUrl()
-  }, [])
+  }, [initializeFromUrl])
 
   // Redirect to login if not authenticated
   if (!isAuthenticated) {

--- a/src/frame.tsx
+++ b/src/frame.tsx
@@ -37,3 +37,5 @@ function FrameApp() {
 }
 
 createRoot(document.getElementById('frame-root')!).render(<FrameApp />)
+
+export default FrameApp

--- a/src/store/useHarnessStore.ts
+++ b/src/store/useHarnessStore.ts
@@ -13,7 +13,7 @@ interface Store extends TestHarnessState, TestHarnessActions {
 
 export const useHarnessStore = create<Store>((set, get) => ({
   apiUrl: 'https://api.example.com',
-  frameSource: 'https://source.example.com',
+  frameSource: `${window.location.origin}/frame.html`,
   privyAppId: '123456789',
   screenSize: 'desktop',
   isDashboardVisible: true,


### PR DESCRIPTION
## Summary
- fix eslint warnings around FrameApp and TestHarness
- default frame source to the local frame.html
- configure PostCSS with Tailwind and Autoprefixer

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build` *(fails: Tailwind CSS requires `@tailwindcss/postcss`)*