### PR TITLE
Fix PostCSS config for Tailwind v4

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {}
   }
 }


### PR DESCRIPTION
## Summary
- use `@tailwindcss/postcss` in PostCSS config

## Testing
- `npm run ok`