### PR TITLE
Remove heavy @privy-io/react-auth dep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@artifact/client": "npm:@jsr/artifact__client@^0.0.79",
-        "@privy-io/react-auth": "^2.13.3",
         "@tailwindcss/vite": "^4.1.7",
         "debug": "^4.4.1",
         "from": "^0.1.7",
@@ -2148,74 +2147,6 @@
       "license": "MIT",
       "dependencies": {
         "base-x": "^4.0.0"
-      }
-    },
-    "node_modules/@privy-io/react-auth": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-2.13.3.tgz",
-      "integrity": "sha512-ipXjFyKEaDgnbqPpwhsPY/D0IdXXkey/HRyTh1lGW3BW8oLpjCKO1owNVGKkJoEhvv+WPfA2nULtecQ56pZ+BA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@coinbase/wallet-sdk": "^4.3.2",
-        "@floating-ui/react": "^0.26.22",
-        "@headlessui/react": "^2.2.0",
-        "@heroicons/react": "^2.1.1",
-        "@marsidev/react-turnstile": "^0.4.1",
-        "@metamask/eth-sig-util": "^6.0.0",
-        "@privy-io/chains": "0.0.1",
-        "@privy-io/ethereum": "0.0.1",
-        "@privy-io/js-sdk-core": "0.50.3",
-        "@reown/appkit": "^1.7.2",
-        "@scure/base": "^1.2.5",
-        "@simplewebauthn/browser": "^9.0.1",
-        "@solana/wallet-adapter-base": "0.9.23",
-        "@solana/wallet-standard-wallet-adapter-base": "^1.1.2",
-        "@solana/wallet-standard-wallet-adapter-react": "^1.1.2",
-        "@wallet-standard/app": "^1.0.1",
-        "@walletconnect/ethereum-provider": "2.19.2",
-        "base64-js": "^1.5.1",
-        "dotenv": "^16.0.3",
-        "encoding": "^0.1.13",
-        "eventemitter3": "^5.0.1",
-        "fast-password-entropy": "^1.1.1",
-        "jose": "^4.15.5",
-        "js-cookie": "^3.0.5",
-        "lokijs": "^1.5.12",
-        "md5": "^2.3.0",
-        "mipd": "^0.0.7",
-        "ofetch": "^1.3.4",
-        "pino-pretty": "^10.0.0",
-        "qrcode": "^1.5.1",
-        "react-device-detect": "^2.2.2",
-        "secure-password-utilities": "^0.2.1",
-        "styled-components": "^6.1.13",
-        "stylis": "^4.3.4",
-        "tinycolor2": "^1.6.0",
-        "uuid": ">=8 <10",
-        "viem": "^2.24.1",
-        "zustand": "^5.0.0"
-      },
-      "peerDependencies": {
-        "@abstract-foundation/agw-client": "^1.0.0",
-        "@solana/spl-token": "^0.4.9",
-        "@solana/web3.js": "^1.95.8",
-        "permissionless": "^0.2.10",
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19"
-      },
-      "peerDependenciesMeta": {
-        "@abstract-foundation/agw-client": {
-          "optional": true
-        },
-        "@solana/spl-token": {
-          "optional": true
-        },
-        "@solana/web3.js": {
-          "optional": true
-        },
-        "permissionless": {
-          "optional": true
-        }
       }
     },
     "node_modules/@react-aria/focus": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
   },
   "dependencies": {
     "@artifact/client": "npm:@jsr/artifact__client@^0.0.79",
-    "@privy-io/react-auth": "^2.13.3",
     "@tailwindcss/vite": "^4.1.7",
     "debug": "^4.4.1",
     "from": "^0.1.7",

--- a/src/types/privy-io__react-auth.d.ts
+++ b/src/types/privy-io__react-auth.d.ts
@@ -1,0 +1,27 @@
+declare module '@privy-io/react-auth' {
+  import type { ReactNode } from 'react'
+
+  export interface PrivyProviderProps {
+    appId: string
+    clientId?: string
+    config?: unknown
+    children: ReactNode
+  }
+
+  export const PrivyProvider: (props: PrivyProviderProps) => JSX.Element
+
+  export interface User {
+    id: string
+  }
+
+  export interface PrivyInterface {
+    ready: boolean
+    authenticated: boolean
+    user: User | null
+    login: (options?: unknown) => void
+  }
+
+  export function usePrivy(): PrivyInterface
+
+  export function useIdentityToken(): { identityToken: string | null }
+}


### PR DESCRIPTION
## Summary
- drop `@privy-io/react-auth` from dependencies
- provide lightweight local typings so TypeScript still understands the imports

## Testing
- `npm run type-check`
- `npm run lint`
- `npm run format`
