### PR TITLE
Implement blanking url params

### DIFF
--- a/src/components/TestHarness.tsx
+++ b/src/components/TestHarness.tsx
@@ -41,14 +41,19 @@ const TestHarness: React.FC = () => {
   const frameUrl = React.useMemo(() => {
     const base = frameSource || '/frame.html'
     const url = new URL(base, window.location.origin)
-    url.searchParams.set('apiUrl', apiUrl)
-    url.searchParams.set('frameSource', base)
-    url.searchParams.set('privyAppId', privyAppId)
-    if (scope.repo) url.searchParams.set('repo', scope.repo)
-    if (scope.branch) url.searchParams.set('branch', scope.branch)
-    if (scope.commit) url.searchParams.set('commit', scope.commit)
-    if (scope.path) url.searchParams.set('path', scope.path)
-    return url.toString()
+    const params: Record<string, string> = {
+      apiUrl,
+      frameSource: base,
+      privyAppId
+    }
+    if (scope.repo) params.repo = scope.repo
+    if (scope.branch) params.branch = scope.branch
+    if (scope.commit) params.commit = scope.commit
+    if (scope.path) params.path = scope.path
+    const query = Object.entries(params)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('&')
+    return `${url.origin}${url.pathname}?${query}`
   }, [apiUrl, frameSource, privyAppId, scope])
 
   useEffect(() => {

--- a/src/frame.tsx
+++ b/src/frame.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from 'react-dom/client'
+import { useEffect } from 'react'
 import { ArtifactFrame } from '@artifact/client'
 import { HOST_SCOPE } from '@artifact/client/api'
 import ComponentUnderTest from './components/ComponentUnderTest'
@@ -13,6 +14,12 @@ function FrameApp() {
     commit: params.get('commit') || '',
     path: params.get('path') || ''
   }
+
+  useEffect(() => {
+    if (window.location.search) {
+      window.history.replaceState(null, '', window.location.pathname)
+    }
+  }, [])
 
   return (
     <ArtifactFrame

--- a/src/store/useHarnessStore.ts
+++ b/src/store/useHarnessStore.ts
@@ -30,7 +30,7 @@ export const useHarnessStore = create<Store>((set, get) => ({
   openFullscreen: () => {
     const state = get()
     const baseUrl = window.location.href.split('?')[0]
-    const params = new URLSearchParams({
+    const params = {
       hideDashboard: 'true',
       apiUrl: state.apiUrl,
       frameSource: state.frameSource,
@@ -41,8 +41,12 @@ export const useHarnessStore = create<Store>((set, get) => ({
       branch: state.scope.branch || '',
       commit: state.scope.commit || '',
       path: state.scope.path || ''
-    })
-    const fullUrl = `${baseUrl}?${params.toString()}`
+    }
+    const query = Object.entries(params)
+      .filter(([, v]) => v)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('&')
+    const fullUrl = query ? `${baseUrl}?${query}` : baseUrl
     window.open(fullUrl, '_blank')
   },
   setBackground: (background: BackgroundType) => set({ background }),
@@ -72,5 +76,10 @@ export const useHarnessStore = create<Store>((set, get) => ({
     if (branch) set((state) => ({ scope: { ...state.scope, branch } }))
     if (commit) set((state) => ({ scope: { ...state.scope, commit } }))
     if (path) set((state) => ({ scope: { ...state.scope, path } }))
+
+    // Remove query parameters from the address bar once consumed
+    if (window.location.search) {
+      window.history.replaceState(null, '', window.location.pathname)
+    }
   }
 }))

--- a/src/types/debug.d.ts
+++ b/src/types/debug.d.ts
@@ -1,0 +1,1 @@
+declare module 'debug'


### PR DESCRIPTION
## Summary
- avoid url encoding when building frame URL and fullscreen link
- clear url params from both harness and frame after they're consumed
- add missing debug module declaration

## Testing
- `npm run -s ok`