### PR TITLE
Use import map for Privy auth

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Component Test Harness with Dashboard</title>
+    <script type="importmap">
+      {
+        "imports": {
+          "@privy-io/react-auth": "https://cdn.jsdelivr.net/npm/@privy-io/react-auth@2.13.3/+esm"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import path from 'path'
 export default defineConfig({
   plugins: [react(), tailwindcss()],
 
-  optimizeDeps: { exclude: ['lucide-react'] },
+  optimizeDeps: { exclude: ['lucide-react', '@privy-io/react-auth'] },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src')
@@ -23,7 +23,8 @@ export default defineConfig({
       input: {
         main: path.resolve(__dirname, 'index.html'),
         frame: path.resolve(__dirname, 'frame.html')
-      }
+      },
+      external: ['@privy-io/react-auth']
     }
   }
 })


### PR DESCRIPTION
## Summary
- load `@privy-io/react-auth` from CDN with an import map
- mark the module as external for dev and build

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
