### PR TITLE
Fix build by removing deprecated tailwind plugin

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,5 @@
 export default {
   plugins: {
-    tailwindcss: {},
     autoprefixer: {}
   }
 }


### PR DESCRIPTION
## Summary
- update PostCSS config to remove deprecated `tailwindcss` plugin

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683bbd0f4740832b8811d2b03a71e960