### PR TITLE
Use privy logout for sign out

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import ScopeForm from './dashboard/ScopeForm'
 import DisplayOptions from './dashboard/DisplayOptions'
 import ComponentInfo from './dashboard/ComponentInfo'
 import { useHarnessStore } from '../store/useHarnessStore'
+import { usePrivy } from '@privy-io/react-auth'
 
 const Dashboard: React.FC = () => {
   const {
@@ -19,12 +20,12 @@ const Dashboard: React.FC = () => {
     setPrivyAppId,
     setScreenSize,
     toggleBorder,
-    signOut,
     openFullscreen,
     setBackground,
     setScope,
     resetParams
   } = useHarnessStore()
+  const { logout } = usePrivy()
 
   return (
     <div className="w-full bg-white shadow-md border-b border-gray-200 px-4 py-4 transition-all">
@@ -42,7 +43,7 @@ const Dashboard: React.FC = () => {
               <span>View Fullscreen</span>
             </button>
             <button
-              onClick={signOut}
+              onClick={logout}
               className="flex items-center gap-2 px-3 py-1.5 bg-gray-100 hover:bg-gray-200 rounded-lg text-gray-700 transition-colors"
             >
               <LogOut size={16} />

--- a/src/components/TestHarness.tsx
+++ b/src/components/TestHarness.tsx
@@ -30,7 +30,6 @@ const TestHarness: React.FC = () => {
     privyAppId,
     screenSize,
     isDashboardVisible,
-    isAuthenticated,
     showBorder,
     background,
     scope,
@@ -59,28 +58,6 @@ const TestHarness: React.FC = () => {
   useEffect(() => {
     initializeFromUrl()
   }, [initializeFromUrl])
-
-  // Redirect to login if not authenticated
-  if (!isAuthenticated) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="bg-white p-8 rounded-lg shadow-md max-w-md w-full">
-          <h2 className="text-2xl font-bold text-gray-800 mb-6">
-            Sign In Required
-          </h2>
-          <p className="text-gray-600 mb-6">
-            You have been signed out. Refresh the page to sign in again.
-          </p>
-          <button
-            onClick={() => window.location.reload()}
-            className="w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition-colors"
-          >
-            Refresh Page
-          </button>
-        </div>
-      </div>
-    )
-  }
 
   const backgroundStyles = getBackgroundStyles(background)
 

--- a/src/store/useHarnessStore.ts
+++ b/src/store/useHarnessStore.ts
@@ -21,7 +21,6 @@ const defaultState: TestHarnessState = {
   privyAppId: '123456789',
   screenSize: 'desktop',
   isDashboardVisible: true,
-  isAuthenticated: true,
   showBorder: false,
   background: 'checkered',
   scope: { repo: '', branch: '', commit: '', path: '' }
@@ -35,7 +34,6 @@ export const useHarnessStore = create<Store>()(
       setPrivyAppId: (privyAppId: string) => set({ privyAppId }),
       setScreenSize: (screenSize: ScreenSize) => set({ screenSize }),
       toggleBorder: () => set((state) => ({ showBorder: !state.showBorder })),
-      signOut: () => set({ isAuthenticated: false }),
       openFullscreen: () => {
         const state = get()
         const baseUrl = window.location.href.split('?')[0]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,6 @@ export interface TestHarnessState {
   privyAppId: string
   screenSize: ScreenSize
   isDashboardVisible: boolean
-  isAuthenticated: boolean
   showBorder: boolean
   background: BackgroundType
   scope: ScopeProps
@@ -26,7 +25,6 @@ export interface TestHarnessActions {
   setPrivyAppId: (id: string) => void
   setScreenSize: (size: ScreenSize) => void
   toggleBorder: () => void
-  signOut: () => void
   openFullscreen: () => void
   setBackground: (type: BackgroundType) => void
   setScope: (field: keyof ScopeProps, value: string) => void


### PR DESCRIPTION
## Summary
- invoke privy `logout` from Dashboard
- drop local signOut logic and related `isAuthenticated` state

## Testing
- `npm run lint`
- `npm run type-check`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683bd6c81134832b919d530eaff17c8e